### PR TITLE
Fix flashinfer-cubin version mismatch in vLLM Modal deployment 

### DIFF
--- a/src/nemotron_speech/modal/vllm_modal.py
+++ b/src/nemotron_speech/modal/vllm_modal.py
@@ -14,7 +14,7 @@ vllm_image = (
     .uv_pip_install(
         "vllm>=0.12.0",
         "huggingface-hub==0.36.0",
-        "flashinfer-cubin",
+        "flashinfer-cubin==0.5.3",
         "cuda-python==12.8.0",
     )
     .env({


### PR DESCRIPTION
Pins flashinfer-cubin to version 0.5.3 to match the flashinfer-python version required by vLLM 0.13.0. This fixes a container startup failure where the vLLM Modal deployment would crash with `RuntimeError: flashinfer-cubin version (0.6.1) does not match flashinfer version (0.5.3)`.                                    
                                                                                                                                                                    
Fixes pipecat-ai#6                                                                                                                                               
                                                                                                                                                                    
🤖 Generated with [Claude Code](https://claude.com/claude-code)