### PR TITLE
Fix: Add pydantic and fastapi version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "aiohttp>=3.9.0",
     "numpy>=1.26.0",
     "loguru>=0.7.0",
+    # Fix for FastAPI/Pydantic compatibility
+    "pydantic>=2.0.0,<3.0.0",
+    "fastapi>=0.109.0,<1.0.0",
     # Pipecat bot dependencies
     "pipecat-ai[silero,openai,cartesia,runner,daily,local-smart-turn-v3,webrtc]==0.0.98",
     # Local Riva TTS


### PR DESCRIPTION
Fixes #5 

Added explicit version constraints for pydantic and fastapi to resolve
ImportError when deploying ASR server to Modal.

The error occurred because FastAPI was trying to import 'Undefined' 
from pydantic.fields, which is not available in incompatible versions.

Changes:
- Added pydantic>=2.0.0,<3.0.0 to ensure Pydantic v2 is used
- Added fastapi>=0.109.0,<1.0.0 for compatibility with Pydantic v2
- Placed these dependencies before pipecat-ai to ensure proper resolution

Fixes the ImportError:
  cannot import name 'Undefined' from 'pydantic.fields'

This resolves Modal container startup failures in asr_server_modal.py