### PR TITLE
fix: Minor bugs introduced through updated models.

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -248,9 +248,9 @@ RUN rm -rf /build/pytorch /build/audio
 # =============================================================================
 # Phase 6: NeMo Installation (ASR + TTS)
 # =============================================================================
-# NeMo - main branch, 2025-12-23
-# Includes MagpieTTS longform support (not in r2.6.0 release)
-ARG NEMO_COMMIT=644201898480ec8c8d0a637f0c773825509ac4dc
+# NeMo - main branch, 2026-01-26
+# Includes HindiCharsTokenizer required by magpie_tts_multilingual_357m.
+ARG NEMO_COMMIT=119593e7bf6e854a2136c3b48b804cae97657a0f
 RUN git clone https://github.com/NVIDIA/NeMo.git /opt/nemo && \
     cd /opt/nemo && git checkout ${NEMO_COMMIT}
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ Build time: 2-3 hours (builds PyTorch, NeMo, vLLM, llama.cpp from source for CUD
 ### 2. Start the Container
 
 ```bash
-# Start with default Q8 model (auto-detected from HuggingFace cache)
+# DGX Spark: start with default Q8 model (auto-detected from HuggingFace cache)
 ./scripts/nemotron.sh start
 
-# Or specify a model explicitly
-./scripts/nemotron.sh start --model ~/.cache/huggingface/hub/models--unsloth--Nemotron-3-Nano-30B-A3B-GGUF/snapshots/.../Q8_0.gguf
+# RTX 5090: use the Q4 Nemotron GGUF explicitly
+./scripts/nemotron.sh start --mode llamacpp-q4 --model ~/.cache/huggingface/hub/models--unsloth--Nemotron-3-Nano-30B-A3B-GGUF/snapshots/.../Nemotron-3-Nano-30B-A3B-Q4_K_M.gguf
 
 # Start with vLLM instead of llama.cpp (requires ~72GB VRAM)
 ./scripts/nemotron.sh start --mode vllm
 ```
+
+The local llama.cpp path in this repo is tested against `unsloth/Nemotron-3-Nano-30B-A3B-GGUF`. Other GGUFs may fail if the pinned llama.cpp commit does not yet support their architecture metadata.
 
 ### 3. Run the Voice Bot
 
@@ -307,6 +309,9 @@ Download LLM models (ASR and TTS are auto-downloaded on first run):
 # GGUF quantized models (Q8 and Q4 variants for llama.cpp)
 huggingface-cli download unsloth/Nemotron-3-Nano-30B-A3B-GGUF
 
+# Or download only the RTX 5090-friendly Q4 file
+huggingface-cli download unsloth/Nemotron-3-Nano-30B-A3B-GGUF --include "Nemotron-3-Nano-30B-A3B-Q4_K_M.gguf"
+
 # BF16 full precision (for vLLM)
 huggingface-cli download nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 ```
@@ -321,6 +326,12 @@ For detailed architecture documentation including frame flow, protocols, and tim
 - The buffered LLM service uses single-slot operation (`--parallel 1`)
 - Ensure adequate VRAM for context size (default 16384 tokens)
 - Check for httpx connection issues if generation hangs
+- The pinned llama.cpp build is validated against `unsloth/Nemotron-3-Nano-30B-A3B-GGUF`; other GGUF architectures may fail to load
+
+**Startup fails before LLM launches**:
+- TTS and ASR start before the LLM; first startup can take about a minute while NeMo models warm up
+- `./scripts/nemotron.sh status` is not authoritative during startup; prefer foreground mode or `./scripts/nemotron.sh logs`
+- The default non-vLLM startup timeout is 180 seconds
 
 **vLLM takes 10-15 minutes to start**:
 - This is normal for first startup (model loading, kernel compilation)
@@ -329,3 +340,5 @@ For detailed architecture documentation including frame flow, protocols, and tim
 **vLLM DNS resolution issues**:
 - The container uses `--network=host` in vLLM mode to avoid DNS issues with HuggingFace
 
+**Docker sees the GPU but `--gpus all` still fails**:
+- This repo now launches containers with `--runtime=nvidia --gpus all` because some Docker setups only expose the GPU reliably with the explicit NVIDIA runtime

--- a/docs/unified-container-plan.md
+++ b/docs/unified-container-plan.md
@@ -97,7 +97,7 @@ All repositories are pinned to specific commit SHAs to ensure reproducible build
 |------------|--------|------------|------|-------|
 | PyTorch | main | `32cb1dac896fe212d77073a4a53fee840c13442f` | 2025-12-26 | CUDA 13.1 support |
 | torchaudio | main | `0764cfdedb769e63f3ab8b90bc06541a6a2c0b73` | 2025-12-20 | Compatible with PyTorch main |
-| NeMo | main | `644201898480ec8c8d0a637f0c773825509ac4dc` | 2025-12-23 | Includes MagpieTTS longform |
+| NeMo | main | `119593e7bf6e854a2136c3b48b804cae97657a0f` | 2026-01-26 | Includes Hindi tokenizer required by multilingual Magpie TTS |
 | vLLM | main | `bb80f69bc98cbf062bf030cb11185f7ba526e28a` | 2025-12-21 | Supports Nemotron-H relu2_no_mul |
 | llama.cpp | master | `c18428423018ed214c004e6ecaedb0cbdda06805` | 2025-12-24 | Tested on DGX Spark, avoids mxfp4 build issues |
 
@@ -187,7 +187,7 @@ The startup script supports flexible service selection. Any combination of LLM, 
 For Q8 quantized GGUF models - best balance of quality and VRAM:
 
 ```bash
-docker run -d --name nemotron --gpus all --ipc=host \
+docker run -d --name nemotron --runtime=nvidia --gpus all --ipc=host \
   -v $(pwd):/workspace \
   -v ~/.cache/huggingface:/hf_cache:ro \
   -p 8000:8000 -p 8001:8001 -p 8080:8080 \
@@ -208,7 +208,7 @@ docker run -d --name nemotron --gpus all --ipc=host \
 For Q4 quantized GGUF models - lower VRAM, slightly reduced quality:
 
 ```bash
-docker run -d --name nemotron --gpus all --ipc=host \
+docker run -d --name nemotron --runtime=nvidia --gpus all --ipc=host \
   -v $(pwd):/workspace \
   -v ~/.cache/huggingface:/hf_cache:ro \
   -p 8000:8000 -p 8001:8001 -p 8080:8080 \
@@ -229,7 +229,7 @@ docker run -d --name nemotron --gpus all --ipc=host \
 For BF16 full-precision inference - highest quality:
 
 ```bash
-docker run -d --name nemotron --gpus all --ipc=host \
+docker run -d --name nemotron --runtime=nvidia --gpus all --ipc=host \
   -v $(pwd):/workspace \
   -v $(pwd)/models:/workspace/models:ro \
   -p 8000:8000 -p 8001:8001 -p 8080:8080 \
@@ -458,7 +458,7 @@ For more control, you can run docker commands directly:
 
 ```bash
 # llama.cpp mode
-docker run -d --name nemotron --gpus all --ipc=host \
+docker run -d --name nemotron --runtime=nvidia --gpus all --ipc=host \
   -v $(pwd):/workspace \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   -p 8000:8000 -p 8001:8001 -p 8080:8080 \
@@ -468,7 +468,7 @@ docker run -d --name nemotron --gpus all --ipc=host \
   bash /workspace/scripts/start_unified.sh
 
 # vLLM mode
-docker run -d --name nemotron --gpus all --ipc=host \
+docker run -d --name nemotron --runtime=nvidia --gpus all --ipc=host \
   -v $(pwd):/workspace \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   -p 8000:8000 -p 8001:8001 -p 8080:8080 \

--- a/scripts/nemotron.sh
+++ b/scripts/nemotron.sh
@@ -275,7 +275,7 @@ cmd_start() {
         if [[ "$LLM_MODE" == vllm* ]]; then
             SERVICE_TIMEOUT=900
         else
-            SERVICE_TIMEOUT=60
+            SERVICE_TIMEOUT=180
         fi
     fi
 
@@ -318,11 +318,14 @@ cmd_start() {
     echo "============================================"
 
     # Build docker run command
-    # Use host network for vLLM mode to avoid DNS issues with HuggingFace
+    # Use the explicit NVIDIA runtime because some Docker setups expose the GPU
+    # reliably only when --runtime=nvidia is specified alongside --gpus all.
+    # Use host network for vLLM mode to avoid DNS issues with HuggingFace.
     if [[ "$LLM_MODE" == vllm* ]]; then
         DOCKER_ARGS=(
             run
             --name "$CONTAINER_NAME"
+            --runtime=nvidia
             --gpus all
             --network=host
             --ipc=host
@@ -340,6 +343,7 @@ cmd_start() {
         DOCKER_ARGS=(
             run
             --name "$CONTAINER_NAME"
+            --runtime=nvidia
             --gpus all
             --ipc=host
             -v "$PROJECT_DIR:/workspace"

--- a/scripts/start_unified.sh
+++ b/scripts/start_unified.sh
@@ -22,7 +22,7 @@
 #   VLLM_ATTENTION_BACKEND        - Attention backend (default: TRITON_ATTN)
 #
 # General:
-#   SERVICE_TIMEOUT               - Seconds to wait for each service to start (default: 60)
+#   SERVICE_TIMEOUT               - Seconds to wait for each service to start (default: 180)
 #   HUGGINGFACE_ACCESS_TOKEN      - HuggingFace token for gated models
 #
 # Logs are written to /var/log/nemotron/{asr,tts,llm}.log for external access.
@@ -53,11 +53,12 @@ ENABLE_LLM="${ENABLE_LLM:-true}"
 ENABLE_ASR="${ENABLE_ASR:-true}"
 ENABLE_TTS="${ENABLE_TTS:-true}"
 LLM_MODE="${LLM_MODE:-llamacpp-q8}"
-# vLLM needs ~15 minutes to load the model, llama.cpp only needs ~60s
+# vLLM needs ~15 minutes to load the model; llama.cpp + NeMo startup can
+# still exceed a minute on a cold start, so use a higher default there too.
 if [[ "$LLM_MODE" == "vllm" ]]; then
     SERVICE_TIMEOUT="${SERVICE_TIMEOUT:-900}"
 else
-    SERVICE_TIMEOUT="${SERVICE_TIMEOUT:-60}"
+    SERVICE_TIMEOUT="${SERVICE_TIMEOUT:-180}"
 fi
 LLAMA_PARALLEL="${LLAMA_PARALLEL:-1}"
 LLAMA_CTX_SIZE="${LLAMA_CTX_SIZE:-16384}"

--- a/src/nemotron_speech/streaming_tts.py
+++ b/src/nemotron_speech/streaming_tts.py
@@ -166,8 +166,6 @@ class StreamingMagpieTTS:
 
             audio_codes_lens = torch.full((text.size(0),), 1, device=text.device).long()
             audio_codes_input = audio_codes_bos
-            audio_codes_mask = get_mask_from_lengths(audio_codes_lens)
-
             # Prepare CFG if enabled
             if cfg.use_cfg:
                 dummy_cond, dummy_cond_mask, dummy_add_dec_input, dummy_add_dec_mask, _ = (
@@ -189,7 +187,11 @@ class StreamingMagpieTTS:
             # Main generation loop
             for idx in range(cfg.max_decoder_steps // model.frame_stacking_factor):
                 # Generate next token(s)
-                audio_codes_embedded = model.embed_audio_tokens(audio_codes_input)
+                audio_codes_embedded, audio_codes_embedded_lens = model.embed_audio_tokens(
+                    audio_tokens=audio_codes_input,
+                    audio_tokens_lens=audio_codes_lens,
+                )
+                audio_codes_mask = get_mask_from_lengths(audio_codes_embedded_lens)
 
                 if context_tensors.additional_decoder_input is not None:
                     _audio_codes_embedded = torch.cat(
@@ -272,8 +274,7 @@ class StreamingMagpieTTS:
                 all_predictions.append(audio_codes_next)
                 pending_tokens.append(audio_codes_next)
                 audio_codes_input = torch.cat([audio_codes_input, audio_codes_next], dim=-1)
-                audio_codes_lens = audio_codes_lens + 1
-                audio_codes_mask = get_mask_from_lengths(audio_codes_lens)
+                audio_codes_lens = audio_codes_lens + model.frame_stacking_factor
 
                 # Check if we should decode and yield a chunk
                 total_pending_frames = len(pending_tokens) * model.frame_stacking_factor
@@ -329,7 +330,7 @@ class StreamingMagpieTTS:
                     else:
                         decode_lens = torch.tensor([decode_codes.size(-1)], device=decode_codes.device).long()
 
-                    audio, audio_len = model.codes_to_audio(decode_codes, decode_lens)
+                    audio, audio_len, _ = model.codes_to_audio(decode_codes, decode_lens)
 
                     # Extract new audio (skip overlap region, but preserve some for server-side blending)
                     # The preserved overlap represents the same time period as the previous chunk's tail,
@@ -387,7 +388,7 @@ class StreamingMagpieTTS:
                 else:
                     decode_lens = torch.tensor([decode_codes.size(-1)], device=decode_codes.device).long()
 
-                audio, _ = model.codes_to_audio(decode_codes, decode_lens)
+                audio, _, _ = model.codes_to_audio(decode_codes, decode_lens)
 
                 # Preserve overlap for server-side blending (same as main loop)
                 if overlap_samples > 0:

--- a/src/nemotron_speech/tts_server.py
+++ b/src/nemotron_speech/tts_server.py
@@ -75,13 +75,35 @@ async def load_model(model_id: str = "nvidia/magpie_tts_multilingual_357m"):
 
         def _load():
             from nemo.collections.tts.models import MagpieTTSModel
+            from nemo.collections.common.tokenizers.text_to_speech import tts_tokenizers
 
             # Ensure HuggingFace token is set
             hf_token = os.environ.get("HUGGINGFACE_ACCESS_TOKEN") or os.environ.get("HF_TOKEN")
             if hf_token:
                 os.environ["HF_TOKEN"] = hf_token
 
-            model = MagpieTTSModel.from_pretrained(model_id)
+            if not hasattr(tts_tokenizers, "HindiCharsTokenizer"):
+                raise RuntimeError(
+                    "Installed NeMo build is too old for "
+                    f"{model_id}. The multilingual Magpie config expects "
+                    "HindiCharsTokenizer, which was added after the currently "
+                    "pinned NeMo commit. Rebuild the Docker image from the "
+                    "current repo so Dockerfile.unified can install the newer "
+                    "NeMo revision."
+                )
+
+            try:
+                model = MagpieTTSModel.from_pretrained(model_id)
+            except Exception as exc:
+                if "HindiCharsTokenizer" in str(exc):
+                    raise RuntimeError(
+                        "Failed to load Magpie TTS because the installed NeMo "
+                        "build does not provide HindiCharsTokenizer. Rebuild "
+                        "the Docker image from the current repo to pick up the "
+                        "updated NeMo commit in Dockerfile.unified."
+                    ) from exc
+                raise
+
             model = model.cuda()
             model.eval()
             return model


### PR DESCRIPTION
Closes #12

This updates the pinned NeMo revision for multilingual Magpie TTS, fixes local streaming TTS warmup against current NeMo APIs, makes Docker use the explicit NVIDIA runtime, and documents the supported Nemotron GGUF path for llama.cpp.